### PR TITLE
Subschemes improvements

### DIFF
--- a/lib/paradocs.rb
+++ b/lib/paradocs.rb
@@ -19,8 +19,9 @@ module Paradocs
 
   def self.config
     @config ||= OpenStruct.new(
-      explicit_errors:  false,
-      whitelisted_keys: []
+      explicit_errors:     false,
+      whitelisted_keys:    [],
+      default_schema_name: :schema
     )
   end
 

--- a/lib/paradocs/context.rb
+++ b/lib/paradocs/context.rb
@@ -13,7 +13,7 @@ module Paradocs
   end
 
   class Context
-    attr_reader :environment, :subschemes
+    attr_reader :environment
     def initialize(path=nil, top=Top.new, environment={}, subschemes={})
       @top = top
       @path = Array(path).compact
@@ -21,12 +21,11 @@ module Paradocs
       @subschemes = subschemes
     end
 
-    def subschema_reduce!(subschema_name)
-      reduced = @subschemes.clone
-      subschema = reduced.delete(subschema_name)
-      return self unless subschema
-      reduced.merge!(subschema.subschemes)
-      self.class.new(@path, @top, @environment, reduced)
+    def subschema(subschema_name)
+      subschema = @subschemes[subschema_name]
+      return unless subschema
+      @subschemes.merge!(subschema.subschemes)
+      subschema
     end
 
     def errors
@@ -38,7 +37,7 @@ module Paradocs
     end
 
     def sub(key)
-      self.class.new(path + [key], top, environment, subschemes)
+      self.class.new(path + [key], top, environment, @subschemes)
     end
 
     protected

--- a/lib/paradocs/dsl.rb
+++ b/lib/paradocs/dsl.rb
@@ -22,16 +22,15 @@ module Paradocs
     #
     #   foo.params # => {title: "A title", age: 20}
     #
-    DEFAULT_SCHEMA_NAME = :schema
 
     def self.included(base)
       base.extend(ClassMethods)
-      base.schemas = {DEFAULT_SCHEMA_NAME => Paradocs::Schema.new}
+      base.schemas = {Paradocs.config.default_schema_name => Paradocs::Schema.new}
     end
 
     module ClassMethods
       def schema=(sc)
-        @schemas[DEFAULT_SCHEMA_NAME] = sc
+        @schemas[Paradocs.config.default_schema_name] = sc
       end
 
       def schemas=(sc)
@@ -46,7 +45,7 @@ module Paradocs
 
       def schema(*args, &block)
         options = args.last.is_a?(Hash) ? args.last : {}
-        key = args.first.is_a?(Symbol) ? args.first : DEFAULT_SCHEMA_NAME
+        key = args.first.is_a?(Symbol) ? args.first : Paradocs.config.default_schema_name
         current_schema = @schemas.fetch(key) { Paradocs::Schema.new }
         new_schema = if block_given? || options.any?
           Paradocs::Schema.new(options, &block)
@@ -59,13 +58,6 @@ module Paradocs
         @schemas[key] = current_schema ? current_schema.merge(new_schema) : new_schema
         paradocs_after_define_schema(@schemas[key])
         @schemas[key]
-      end
-
-      def subschema_for(main_schema, name:, **kwargs, &block)
-        # subschema = schema(name, kwargs, &block)
-        @schemas[main_schema].subschema(name, kwargs, &block)
-        # @schemas[main_schema].subschemes[name] = subschema
-        @schemas[main_schema]
       end
 
       def paradocs_after_define_schema(sc)

--- a/lib/paradocs/dsl.rb
+++ b/lib/paradocs/dsl.rb
@@ -50,7 +50,7 @@ module Paradocs
         current_schema = @schemas.fetch(key) { Paradocs::Schema.new }
         new_schema = if block_given? || options.any?
           Paradocs::Schema.new(options, &block)
-        elsif args.first.respond_to?(:schema)
+        elsif args.first.is_a?(Paradocs::Schema)
           args.first
         end
 
@@ -62,9 +62,10 @@ module Paradocs
       end
 
       def subschema_for(main_schema, name:, **kwargs, &block)
-        subschema = schema(name, kwargs, &block)
-        @schemas[main_schema].subschemes[name] = subschema
-        subschema
+        # subschema = schema(name, kwargs, &block)
+        @schemas[main_schema].subschema(name, kwargs, &block)
+        # @schemas[main_schema].subschemes[name] = subschema
+        @schemas[main_schema]
       end
 
       def paradocs_after_define_schema(sc)

--- a/lib/paradocs/field.rb
+++ b/lib/paradocs/field.rb
@@ -36,11 +36,16 @@ module Paradocs
     def mutates_schema!(&block)
       @mutation_block   ||= block if block_given?
       @expects_mutation = @expects_mutation.nil? && true
+      meta mutates_schema: @mutation_block
       @mutation_block
     end
 
+    def mutates_schema?
+      !!@mutation_block
+    end
+
     def expects_mutation?
-      @mutation_block && @expects_mutation
+      mutates_schema? && @expects_mutation
     end
 
     def policy(key, *args)
@@ -57,6 +62,10 @@ module Paradocs
       sc = (sc ? sc : Schema.new(&block))
       meta schema: sc
       policy sc.schema
+    end
+
+    def transparent?
+      !!meta_data[:transparent]
     end
 
     def visit(meta_key = nil, &visitor)

--- a/lib/paradocs/field.rb
+++ b/lib/paradocs/field.rb
@@ -14,6 +14,8 @@ module Paradocs
       @default_block = nil
       @meta_data = {}
       @policies = []
+      @mutation_block = nil
+      @expects_mutation = nil
     end
 
     def meta(hash = nil)
@@ -31,12 +33,23 @@ module Paradocs
       self
     end
 
+    def mutates_schema!(&block)
+      @mutation_block   ||= block if block_given?
+      @expects_mutation = @expects_mutation.nil? && true
+      @mutation_block
+    end
+
+    def expects_mutation?
+      @mutation_block && @expects_mutation
+    end
+
     def policy(key, *args)
       pol = lookup(key, args)
       meta pol.meta_data
       policies << pol
       self
     end
+
     alias_method :type, :policy
     alias_method :rule, :policy
 
@@ -53,6 +66,12 @@ module Paradocs
       else
         meta_key ? meta_data[meta_key] : yield(self)
       end
+    end
+
+    def subschema_for_mutation(payload, env)
+      subschema_name = @mutation_block.call(payload[key], key, payload, env) if @mutation_block
+      @expects_mutation = false
+      subschema_name
     end
 
     def resolve(payload, context)

--- a/lib/paradocs/field_dsl.rb
+++ b/lib/paradocs/field_dsl.rb
@@ -24,5 +24,9 @@ module Paradocs
     def whitelisted
       policy :whitelisted
     end
+
+    def transparent
+      meta transparent: true
+    end
   end
 end

--- a/lib/paradocs/schema.rb
+++ b/lib/paradocs/schema.rb
@@ -110,7 +110,8 @@ module Paradocs
       end
     end
 
-    def flatten_structure(ignore_transparent: true, root: "", result:{})
+    def flatten_structure(ignore_transparent: true, root: "")
+      flush!
       fields.each_with_object({_errors: [], _subschemes: {}}) do |(name, field), obj|
         json_path = root.empty? ? "$.#{name}" : "#{root}.#{name}"
         meta = field.meta_data.merge(json_path: json_path)

--- a/lib/paradocs/schema.rb
+++ b/lib/paradocs/schema.rb
@@ -4,12 +4,13 @@ require "paradocs/field"
 
 module Paradocs
   class Schema
-    attr_accessor :environment, :subschemes, :subschemes_identifiers
+    attr_accessor :environment
+    attr_reader :subschemes
     def initialize(options = {}, &block)
       @options = options
       @fields = {}
       @subschemes = {}
-      @subschemes_identifiers = {}
+      @subschemes_identifiers = {}  # needed for #subschema_by
       @definitions = []
       @definitions << block if block_given?
       @default_field_policies = []
@@ -19,6 +20,22 @@ module Paradocs
 
     def schema
       self
+    end
+
+    def subschema(*args, &block)
+      ptions = args.last.is_a?(Hash) ? args.last : {}
+      name = args.first.is_a?(Symbol) ? args.shift : Paradocs::DSL::DEFAULT_SCHEMA_NAME
+      current_schema = subschemes.fetch(name) { self.class.new }
+      new_schema = if block_given?
+        sc = self.class.new
+        sc.definitions << block
+        sc
+      elsif args.first.is_a?(self.class)
+        args.first
+      else
+        self.class.new
+      end
+      subschemes[name] = current_schema.merge(new_schema)
     end
 
     def fields
@@ -61,6 +78,8 @@ module Paradocs
         instance.definitions << d
       end
 
+      subschemes.each { |name, subsc| instance.subschema(name, subsc) }
+
       instance.ignore *ignored_field_keys
       instance
     end
@@ -77,8 +96,8 @@ module Paradocs
         end
         obj[field.key] = meta
 
-        next if subschemes_identifiers.empty?
-        obj[:_identifiers] = subschemes_identifiers.keys.first
+        next if @subschemes_identifiers.empty?
+        obj[:_identifiers] = @subschemes_identifiers.keys.first
         if (obj[:_identifiers] - obj.keys).empty?
           parent_subschemes.each do |name, subschema|
             obj[:_subschemes][name] = subschema.structure
@@ -108,8 +127,8 @@ module Paradocs
           obj[:_subschemes][name] = subschema.flatten_structure(json_path)
           obj[:_errors] += obj[:_subschemes][name][:_errors]
         end
-        next if subschemes_identifiers.empty?
-        obj[:_identifiers] = subschemes_identifiers.keys.first.map { |id| "#{humanize.call(root)}.#{id}" }
+        next if @subschemes_identifiers.empty?
+        obj[:_identifiers] = @subschemes_identifiers.keys.first.map { |id| "#{humanize.call(root)}.#{id}" }
       end
     end
 
@@ -137,8 +156,9 @@ module Paradocs
     end
 
     def resolve(payload, environment={})
+      flush! unless subschemes.empty?
       @environment = environment
-      context = Context.new(nil, Top.new, @environment, @subschemes)
+      context = Context.new(nil, Top.new, @environment, subschemes)
       output = coerce(payload, nil, context)
       Results.new(output, context.errors)
     end
@@ -179,19 +199,6 @@ module Paradocs
       end
     end
 
-    def schema_with_subschemes(val, context)
-      apply!
-      instance = self.clone
-      @subschemes_identifiers.each do |dependencies, subschema|
-        new_schema_name = subschema.call(*val.values_at(*dependencies))
-        next unless new_schema_name
-        new_schema = new_schema_name.is_a?(Schema) ? new_schema_name : context.subschemes[new_schema_name]
-        context = context.subschema_reduce!(new_schema_name)
-        new_schema&.copy_into instance
-      end
-      [instance, context]
-    end
-
     protected
 
     attr_reader :definitions, :options
@@ -200,11 +207,9 @@ module Paradocs
 
     attr_reader :default_field_policies, :ignored_field_keys, :expansions
 
-    def coerce_one(val, context, flds: nil)
-      new_schema, context = schema_with_subschemes(val, context)
-      val = reorder_by_schema(val, new_schema)
-
-      flds ||= new_schema.fields
+    def coerce_one(val, context, flds: fields)
+      # subschemes v2
+      invoke_subschemes!(val, context, flds: flds)
       flds.each_with_object({}) do |(_, field), m|
         r = field.resolve(val, context.sub(field.key))
         if r.eligible?
@@ -213,15 +218,21 @@ module Paradocs
       end
     end
 
-    def reorder_by_schema(payload, new_schema)
-      return payload unless payload.is_a?(Hash)
-      sorted = payload.sort_by do |k, _|
-        new_schema.fields.keys.index(k) || payload.keys.count
-      end.to_h
-      # TODO: remove hard-code
-      return payload.class.new(sorted) if payload.class.name.try(:demodulize) == "HashWithIndifferentAccess"
-
-      sorted
+    def invoke_subschemes!(payload, context, flds: fields)
+      invoked_any = false
+      # recoursive definitions call depending on payload
+      flds.clone.each_pair do |_, field|
+        _, mutation_block = @subschemes_identifiers.detect { |ids, _| ids.include? field.key } # v1 compatibility
+        field.mutates_schema! &mutation_block if mutation_block
+        next unless field.expects_mutation?
+        subschema_name = field.subschema_for_mutation(payload, context.environment)
+        subschema = subschemes[subschema_name] || context.subschema(subschema_name)
+        next unless subschema # or may be raise error?
+        subschema.definitions.each { |block| self.instance_exec(&block) }
+        invoked_any = true
+      end
+      # if definitions are applied new subschemes may appear, apply them until they end
+      invoke_subschemes!(payload, context, flds: fields) if invoked_any
     end
 
     class MatchContext
@@ -255,6 +266,11 @@ module Paradocs
         self.instance_exec(options, &d)
       end
       @applied = true
+    end
+
+    def flush!
+      @fields = {}
+      @applied = false
     end
   end
 end

--- a/lib/paradocs/whitelist.rb
+++ b/lib/paradocs/whitelist.rb
@@ -27,21 +27,15 @@ module Paradocs
       def filter!(payload, source_schema)
         schema  = source_schema.clone
         context = Context.new(nil, Top.new, @environment, source_schema.subschemes.clone)
-        # after source_schema.clone the cloned instance is losing parent's proprietes.
-        # in this case after clone is losing #subschemes
-        # TODO: Investigate and fix!
         resolve(payload, schema, context)
       end
 
       def resolve(payload, schema, context)
         filtered_payload = {}
-
+        schema.send(:invoke_subschemes!, payload, context)
         payload.dup.each do |key, value|
           key    = key.to_sym
           schema = Schema.new if schema.nil?
-          schema.send(:apply!)
-
-          schema, context = schema.schema_with_subschemes(payload, context) unless schema.subschemes_identifiers.empty?
 
           if value.is_a?(Hash)
             field_schema = find_schema_by(schema, key)

--- a/spec/schema_structures_spec.rb
+++ b/spec/schema_structures_spec.rb
@@ -15,27 +15,30 @@ describe "Schema structures generation" do
 
   let(:schema) do
     Paradocs::Schema.new do
+      subschema(:highest_level) { field(:test).present } # no mutations on this level -> subschema ignored
+
       field(:data).type(:object).present.schema do
         field(:id).type(:integer).present.policy(:policy_with_error)
         field(:name).type(:string).meta(label: "very important staff")
-        field(:role).type(:string).declared.options(["admin", "user"]).default("user")
+        field(:role).type(:string).declared.options(["admin", "user"]).default("user").mutates_schema! do |*|
+          :test_subschema
+        end
         field(:extra).type(:object).required.schema do
           field(:extra).declared.default(false).policy(:policy_with_silent_error)
         end
 
-        subschema_by(:role) { :subschema }
+        mutation_by!(:name) { :subschema }
+
+        subschema(:subschema) do
+          field(:test_field).present
+        end
+        subschema(:test_subschema) do
+          field(:test1).present
+        end
       end
     end
   end
-  let(:subschema1) do
-    Paradocs::Schema.new do
-      field(:test1).present
-    end
-  end
 
-  before do
-    schema.subschemes[:subschema] = subschema1
-  end
 
   it "generates nested data for documentation generation" do
     expect(schema.structure).to eq({
@@ -53,12 +56,14 @@ describe "Schema structures generation" do
           },
           name: {
             type: :string,
-            label: "very important staff"
+            label: "very important staff",
+            mutates_schema: true
           },
           role: {
             type: :string,
             options: ["admin", "user"],
-            default: "user"
+            default: "user",
+            mutates_schema: true
           },
           extra: {
             type: :object,
@@ -68,12 +73,16 @@ describe "Schema structures generation" do
               _subschemes: {}
             }
           },
-          _identifiers: [:role],
           _subschemes: {
-            subschema: {
+            test_subschema: {
               _errors: [],
               _subschemes: {},
               test1: {required: true, present: true}
+            },
+            subschema: {
+              _errors: [],
+              _subschemes: {},
+              test_field: {required: true, present: true}
             }
           }
         }
@@ -109,18 +118,19 @@ describe "Schema structures generation" do
       "data.name" => {
         type: :string,
         json_path: "$.data.name",
-        label: "very important staff"
+        label: "very important staff",
+        mutates_schema: true
       },
       "data.role" => {
         type: :string,
         options: ["admin", "user"],
         default: "user",
-        json_path: "$.data.role"
+        json_path: "$.data.role",
+        mutates_schema: true
       },
       _errors: [ArgumentError],
-      _identifiers: ["data.role"],
       _subschemes: {
-        subschema: {
+        test_subschema: {
           _errors: [],
           _subschemes: {},
           "data.test1"=>{
@@ -128,6 +138,11 @@ describe "Schema structures generation" do
             present: true,
             json_path: "$.data.test1"
           }
+        },
+        subschema: {
+          _errors: [],
+          _subschemes: {},
+          "data.test_field" => {required: true, present: true, json_path: "$.data.test_field"}
         }
       }
     })

--- a/spec/schema_structures_spec.rb
+++ b/spec/schema_structures_spec.rb
@@ -83,7 +83,6 @@ describe "Schema structures generation" do
   end
 
   it "generates flatten data for documentation generation" do
-    sisi = schema.structure
     expect(schema.flatten_structure).to eq({
       "data" => {
         type: :object,

--- a/spec/subschema_spec.rb
+++ b/spec/subschema_spec.rb
@@ -7,18 +7,17 @@ describe "schemes with subschemes" do
       include Paradocs::DSL
 
       schema(:request) do
-        field(:action).present.options([:update, :delete])
-        subschema_by(:action) do |action|
+        field(:action).present.options([:update, :delete]).mutates_schema! do |action, *|
           action == :update ? :update_schema : :generic_schema
         end
-      end
 
-      subschema_for(:request, name: :update_schema) do
-        field(:event).present
-      end
+        subschema(:update_schema) do
+          field(:event).present
+        end
 
-      subschema_for(:request, name: :generic_schema) do
-        field(:generic_field).present
+        subschema(:generic_schema) do
+          field(:generic_field).present
+        end
       end
 
       def self.validate(schema_name, data)
@@ -43,6 +42,48 @@ describe "schemes with subschemes" do
 
     expect(failed_result.errors).to eq({"$.event"=>["is required"]})
     expect(failed_result.output).to eq({action: :update, event: nil})
+  end
+
+  describe "ghost fields" do
+    let(:schema) do
+      Paradocs::Schema.new do
+        mutation_by!(:error) do |value, key, *args|
+          value.nil? ? :success : :fail
+        end
+
+        subschema(:fail) do
+          field(:fail_field).present
+        end
+        subschema(:success) do
+          field(:success_field).present
+        end
+      end
+    end
+
+    it "mutates schema as expected and doesn't reflect on current schema structure" do
+      structure = {
+        _errors: [],
+        _subschemes: {
+          fail:    {_errors: [], _subschemes: {}, fail_field: {required: true, present: true}},
+          success: {_errors: [], _subschemes: {}, success_field: {required: true, present: true}}
+        }
+      }
+      result = schema.resolve({error: :here})
+      expect(result.errors).to    eq({"$.fail_field"=>["is required"]})
+      expect(result.output).to    eq({error: :here, fail_field: nil})
+      expect(schema.structure).to eq(structure)
+      expect(schema.structure(ignore_transparent: false)).to eq(structure.merge(
+        error: {transparent: true, mutates_schema: true}
+      ))
+
+      result = schema.resolve({})
+      expect(result.errors).to eq({"$.success_field"=>["is required"]})
+      expect(result.output).to eq({success_field: nil})
+      expect(schema.structure).to eq(structure)
+      expect(schema.structure(ignore_transparent: false)).to eq(structure.merge(
+        error: {transparent: true, mutates_schema: true}
+      ))
+    end
   end
 
   describe "nested subschemes" do

--- a/spec/subschema_spec.rb
+++ b/spec/subschema_spec.rb
@@ -44,4 +44,94 @@ describe "schemes with subschemes" do
     expect(failed_result.errors).to eq({"$.event"=>["is required"]})
     expect(failed_result.output).to eq({action: :update, event: nil})
   end
+
+  describe "nested subschemes" do
+    let(:schema) do
+      Paradocs::Schema.new do
+        field(:action).present.options([:update, :delete]).mutates_schema! do |value, key, payload|
+          value == :update ? :update_schema : :generic_schema
+        end
+        field(:event).declared.type(:string)
+
+        subschema(:generic_schema) do
+          field(:generic_field).present
+        end
+
+        subschema(:update_schema) do
+          field(:event).present.mutates_schema! do |value, key, payload|
+            value == :go_deeper ? :very_deep_schema : :deep_update_schema
+          end
+          field(:update_field).present
+          subschema(:deep_update_schema) do
+            field(:field_from_deep_schema).required
+          end
+
+          subschema(:very_deep_schema) do
+            field(:a_hash).type(:object).present.schema do
+              field(:key).present.mutates_schema! { :draft_subschema }
+              subschema(:draft_subschema) do
+                field(:another_event).present.type(:boolean)
+              end
+            end
+          end
+        end
+      end
+    end
+
+    context "update_schema -> deep_update_schema" do
+      let(:payload) {
+        {
+          action:                 :update,
+          event:                  :must_be_present,
+          update_field:           1,
+          field_from_deep_schema: nil
+        }
+      }
+
+      it "builds schema as expected" do
+        result = schema.resolve(payload)
+        expect(result.output).to eq(payload)
+        expect(result.errors).to eq({})
+      end
+
+      it "fails when validation fails in subschemas" do
+        result = schema.resolve(payload.merge(action: :delete))
+        expect(result.output).to eq(action: :delete, event: "must_be_present", generic_field: nil)
+        expect(result.errors).to eq("$.generic_field"=>["is required"])
+      end
+
+      it "overwrites fields: subschema field overwrites parent field" do
+        payload.delete(:event)
+        result = schema.resolve(payload)
+      end
+    end
+
+    context "update_schema -> very_deep_schema -> draft_subschema" do
+      let(:payload) {
+        {
+          action:         :update,
+          event:          :go_deeper,
+          update_field:   1,
+          a_hash:       {
+            key:           :value,
+            another_event: true
+          }
+        }
+      }
+
+      it "builds schema as expected"  do
+        result = schema.resolve(payload)
+        expect(result.output).to eq(payload)
+        expect(result.errors).to eq({})
+      end
+
+      it "fails when payload doesn't suit just built schema" do
+        payload[:a_hash] = {key: :random}
+        result = schema.resolve(payload)
+        payload[:a_hash][:another_event] = nil
+        expect(result.output).to eq(payload)
+        expect(result.errors).to eq({"$.a_hash.another_event"=>["is required"]})
+      end
+    end
+  end
 end

--- a/spec/whitelist_spec.rb
+++ b/spec/whitelist_spec.rb
@@ -14,10 +14,7 @@ describe "classes including Whitelist module" do
         field(:empty_array).type(:array).schema do
           field(:id).whitelisted
         end
-        field(:subschema_1).whitelisted
-        subschema_by(:subschema_1) do |name|
-          name.to_sym
-        end
+        field(:subschema_1).whitelisted.mutates_schema! { |name, *| name.to_sym }
         field(:empty_hash).type(:array).schema do
           field(:id).whitelisted
         end
@@ -26,19 +23,16 @@ describe "classes including Whitelist module" do
           field(:name).present.type(:string)
           field(:empty_string).present.type(:string)
         end
-      end
-    end
 
-    subschema_for(:request, name: :subfield_1) do
-      field(:subfield_1).present.type(:boolean).whitelisted
-      field(:subschema_2)
-      subschema_by(:subschema_2) do |name|
-        name.to_sym
-      end
-    end
+        subschema(:subfield_1) do
+          field(:subfield_1).present.type(:boolean).whitelisted
+          field(:subschema_2).mutates_schema! { |name, *| name.to_sym }
 
-    subschema_for(:request, name: :subfield_2) do
-      field(:subfield_2).present.type(:boolean).whitelisted
+          subschema(:subfield_2) do
+            field(:subfield_2).present.type(:boolean).whitelisted
+          end
+        end
+      end
     end
   end
 


### PR DESCRIPTION
# subschemes review:

added new approaches for subschema definitions:

```rb
field.mutates_schema! { block } # that says which subschema should be invoked
```
```rb
schema.subschema { block } # subschema declaration that should be defined inside schema
```

Example:
```rb
schema do
  field(:action).mutates_schema! do |value, key, payload, context|
    value == :update ? :update_schema : :generic_schema
  end

  subschema(:generic_schema) do
    field(:generic_field).present
  end
  subschema(:update_schema) do 
    field(:another_field).present
  end
end
```