### PR TITLE
Performance improvements, logical changes, added env to Results

### DIFF
--- a/lib/paradocs/extensions/insides.rb
+++ b/lib/paradocs/extensions/insides.rb
@@ -63,8 +63,6 @@ module Paradocs
         end
       end
 
-      private
-
       def meta_keys
         %i(errors subschemes).map! { |key| [key, "#{Paradocs.config.meta_prefix}#{key}".to_sym] }.to_h
       end

--- a/lib/paradocs/extensions/insides.rb
+++ b/lib/paradocs/extensions/insides.rb
@@ -1,0 +1,73 @@
+module Paradocs
+  module Extensions
+    module Insides
+      def structure(ignore_transparent: true, &block)
+        flush!
+        fields.each_with_object({meta_keys[:errors] => [], meta_keys[:subschemes] => {}}) do |(_, field), obj|
+          meta = field.meta_data.dup
+          sc = meta.delete(:schema)
+          meta[:mutates_schema] = true if meta.delete(:mutates_schema)
+          if sc
+            meta[:structure] = sc.structure(ignore_transparent: ignore_transparent, &block)
+            obj[meta_keys[:errors]] += meta[:structure].delete(meta_keys[:errors])
+          else
+            obj[meta_keys[:errors]] += field.possible_errors
+          end
+          obj[field.key] = meta unless ignore_transparent && field.transparent?
+          yield(field.key, meta) if block_given?
+
+          next unless field.mutates_schema?
+          subschemes.each do |name, subschema|
+            obj[meta_keys[:subschemes]][name] = subschema.structure(ignore_transparent: ignore_transparent, &block)
+            obj[meta_keys[:errors]] += obj[meta_keys[:subschemes]][name][meta_keys[:errors]]
+          end
+        end
+      end
+
+      def flatten_structure(ignore_transparent: true, root: "", &block)
+        flush!
+        fields.each_with_object({meta_keys[:errors] => [], meta_keys[:subschemes] => {}}) do |(name, field), obj|
+          json_path = root.empty? ? "$.#{name}" : "#{root}.#{name}"
+          meta = field.meta_data.merge(json_path: json_path)
+          sc = meta.delete(:schema)
+          meta[:mutates_schema] = true if meta.delete(:mutates_schema)
+          json_path << "[]" if meta[:type] == :array
+          humanized_name = json_path.gsub("[]", "")[2..-1]
+          obj[humanized_name] = meta unless ignore_transparent && field.transparent?
+
+          if sc
+            deep_result = sc.flatten_structure(ignore_transparent: ignore_transparent, root: json_path, &block)
+            obj[meta_keys[:errors]] += deep_result.delete(meta_keys[:errors])
+            obj[meta_keys[:subschemes]].merge!(deep_result.delete(meta_keys[:subschemes]))
+            obj.merge!(deep_result)
+          else
+            obj[meta_keys[:errors]] += field.possible_errors
+          end
+          yield(humanized_name, meta) if block_given?
+          next unless field.mutates_schema?
+          subschemes.each do |name, subschema|
+            obj[meta_keys[:subschemes]][name] ||= subschema.flatten_structure(ignore_transparent: ignore_transparent, root: root, &block)
+            obj[meta_keys[:errors]] += obj[meta_keys[:subschemes]][name][meta_keys[:errors]]
+          end
+        end
+      end
+
+      def walk(meta_key = nil, &visitor)
+        r = visit(meta_key, &visitor)
+        Results.new(r, {}, {})
+      end
+
+      def visit(meta_key = nil, &visitor)
+        fields.each_with_object({}) do |(_, field), m|
+          m[field.key] = field.visit(meta_key, &visitor)
+        end
+      end
+
+      private
+
+      def meta_keys
+        %i(errors subschemes).map! { |key| [key, "#{Paradocs.config.meta_prefix}#{key}".to_sym] }.to_h
+      end
+    end
+  end
+end

--- a/lib/paradocs/field.rb
+++ b/lib/paradocs/field.rb
@@ -7,10 +7,9 @@ module Paradocs
     attr_reader :key, :meta_data
     Result = Struct.new(:eligible?, :value)
 
-    def initialize(key, registry = Paradocs.registry)
+    def initialize(key)
       @key = key
       @policies = []
-      @registry = registry
       @default_block = nil
       @meta_data = {}
       @policies = []
@@ -117,7 +116,7 @@ module Paradocs
     end
 
     private
-    attr_reader :policies, :registry, :default_block
+    attr_reader :policies, :default_block
 
     def resolve_one(policy, value, payload, context)
       begin
@@ -144,7 +143,7 @@ module Paradocs
     end
 
     def lookup(key, args)
-      obj = key.is_a?(Symbol) ? registry.policies[key] : key
+      obj = key.is_a?(Symbol) ? Paradocs.registry.policies[key] : key
 
       raise ConfigurationError, "No policies defined for #{key.inspect}" unless obj
       obj.respond_to?(:new) ? obj.new(*args) : obj

--- a/lib/paradocs/results.rb
+++ b/lib/paradocs/results.rb
@@ -1,9 +1,9 @@
 module Paradocs
   class Results
-    attr_reader :output, :errors
+    attr_reader :output, :errors, :environment
 
-    def initialize(output, errors)
-      @output, @errors = output, errors
+    def initialize(output, errors, environment)
+      @output, @errors, @environment = output, errors, environment
     end
 
     def valid?

--- a/lib/paradocs/schema.rb
+++ b/lib/paradocs/schema.rb
@@ -198,7 +198,6 @@ module Paradocs
       default_field_policies.reduce(field) {|f, policy_name| f.policy(policy_name) }
     end
 
-
     def apply!
       return if @applied
       definitions.each do |d|

--- a/lib/paradocs/schema.rb
+++ b/lib/paradocs/schema.rb
@@ -1,9 +1,12 @@
 require "paradocs/context"
 require "paradocs/results"
 require "paradocs/field"
+require "paradocs/extensions/insides"
 
 module Paradocs
   class Schema
+    include Extensions::Insides
+
     attr_accessor :environment
     attr_reader :subschemes
     def initialize(options={}, &block)
@@ -88,57 +91,6 @@ module Paradocs
       instance
     end
 
-    def structure(ignore_transparent: true, &block)
-      flush!
-      fields.each_with_object({meta_keys[:errors] => [], meta_keys[:subschemes] => {}}) do |(_, field), obj|
-        meta = field.meta_data.dup
-        sc = meta.delete(:schema)
-        meta[:mutates_schema] = true if meta.delete(:mutates_schema)
-        if sc
-          meta[:structure] = sc.structure(ignore_transparent: ignore_transparent, &block)
-          obj[meta_keys[:errors]] += meta[:structure].delete(meta_keys[:errors])
-        else
-          obj[meta_keys[:errors]] += field.possible_errors
-        end
-        obj[field.key] = meta unless ignore_transparent && field.transparent?
-        yield(field.key, meta) if block_given?
-
-        next unless field.mutates_schema?
-        subschemes.each do |name, subschema|
-          obj[meta_keys[:subschemes]][name] = subschema.structure(ignore_transparent: ignore_transparent, &block)
-          obj[meta_keys[:errors]] += obj[meta_keys[:subschemes]][name][meta_keys[:errors]]
-        end
-      end
-    end
-
-    def flatten_structure(ignore_transparent: true, root: "", &block)
-      flush!
-      fields.each_with_object({meta_keys[:errors] => [], meta_keys[:subschemes] => {}}) do |(name, field), obj|
-        json_path = root.empty? ? "$.#{name}" : "#{root}.#{name}"
-        meta = field.meta_data.merge(json_path: json_path)
-        sc = meta.delete(:schema)
-        meta[:mutates_schema] = true if meta.delete(:mutates_schema)
-        json_path << "[]" if meta[:type] == :array
-        humanized_name = json_path.gsub("[]", "")[2..-1]
-        obj[humanized_name] = meta unless ignore_transparent && field.transparent?
-
-        if sc
-          deep_result = sc.flatten_structure(ignore_transparent: ignore_transparent, root: json_path, &block)
-          obj[meta_keys[:errors]] += deep_result.delete(meta_keys[:errors])
-          obj[meta_keys[:subschemes]].merge!(deep_result.delete(meta_keys[:subschemes]))
-          obj.merge!(deep_result)
-        else
-          obj[meta_keys[:errors]] += field.possible_errors
-        end
-        yield(humanized_name, meta) if block_given?
-        next unless field.mutates_schema?
-        subschemes.each do |name, subschema|
-          obj[meta_keys[:subschemes]][name] ||= subschema.flatten_structure(ignore_transparent: ignore_transparent, root: root, &block)
-          obj[meta_keys[:errors]] += obj[meta_keys[:subschemes]][name][meta_keys[:errors]]
-        end
-      end
-    end
-
     def field(field_or_key)
       f, key = if field_or_key.kind_of?(Field)
         [field_or_key, field_or_key.key]
@@ -162,12 +114,7 @@ module Paradocs
       @environment = environment
       context = Context.new(nil, Top.new, @environment, subschemes)
       output = coerce(payload, nil, context)
-      Results.new(output, context.errors)
-    end
-
-    def walk(meta_key = nil, &visitor)
-      r = visit(meta_key, &visitor)
-      Results.new(r, {})
+      Results.new(output, context.errors, @environment)
     end
 
     def eligible?(value, key, payload)
@@ -180,12 +127,6 @@ module Paradocs
 
     def meta_data
       {}
-    end
-
-    def visit(meta_key = nil, &visitor)
-      fields.each_with_object({}) do |(_, field), m|
-        m[field.key] = field.visit(meta_key, &visitor)
-      end
     end
 
     def coerce(val, _, context)
@@ -214,9 +155,7 @@ module Paradocs
       invoke_subschemes!(val, context, flds: flds)
       flds.each_with_object({}) do |(_, field), m|
         r = field.resolve(val, context.sub(field.key))
-        if r.eligible?
-          m[field.key] = r.value
-        end
+        m[field.key] = r.value if r.eligible?
       end
     end
 
@@ -244,12 +183,11 @@ module Paradocs
     def resolve_expansions(payload, into, context)
       expansions.each do |exp, block|
         payload.each do |key, value|
-          if match = exp.match(key.to_s)
-            fld = MatchContext.new.instance_exec(match, &block)
-            if fld
-              into.update(coerce_one({fld.key => value}, context, flds: {fld.key => apply_default_field_policies_to(fld)}))
-            end
-          end
+          match = exp.match(key.to_s)
+          next unless match
+          fld = MatchContext.new.instance_exec(match, &block)
+          next unless fld
+          into.update(coerce_one({fld.key => value}, context, flds: {fld.key => apply_default_field_policies_to(fld)}))
         end
       end
 
@@ -260,9 +198,6 @@ module Paradocs
       default_field_policies.reduce(field) {|f, policy_name| f.policy(policy_name) }
     end
 
-    def meta_keys
-      %i(errors subschemes).map! { |key| [key, "#{Paradocs.config.meta_prefix}#{key}".to_sym] }.to_h
-    end
 
     def apply!
       return if @applied

--- a/spec/field_spec.rb
+++ b/spec/field_spec.rb
@@ -1,13 +1,12 @@
 require "spec_helper"
 
 describe Paradocs::Field do
-  let(:registry) { Paradocs.registry }
   let(:context)  { Paradocs::Context.new }
 
-  subject { described_class.new(:a_key, registry) }
+  subject { described_class.new(:a_key) }
 
   def register_coercion(name, block)
-    registry.policy name do
+    Paradocs.registry.policy name do
       coerce &block
     end
   end
@@ -351,8 +350,8 @@ describe Paradocs::Field do
     end
 
     it 'chains policies' do
-      registry.policy :general, custom_klass.new("General")
-      registry.policy :commander, custom_klass.new("Commander")
+      Paradocs.registry.policy :general, custom_klass.new("General")
+      Paradocs.registry.policy :commander, custom_klass.new("Commander")
 
       subject
         .policy(:general)
@@ -366,7 +365,7 @@ describe Paradocs::Field do
     end
 
     it "can instantiate policy class and pass arguments" do
-      registry.policy :job_title, custom_klass
+      Paradocs.registry.policy :job_title, custom_klass
 
       subject.policy(:job_title, "Developer")
 


### PR DESCRIPTION
- removed `Paradocs.registry` singleton from the instance attribute of each `Field` instance
- added `environment` object into Results instance, that can be updated through all the policies
- extracted `Schema #walk, #visit, #structure, #flatten_structure` into `Extensions::Insides` module 